### PR TITLE
Fix incorrect parent reference in syncTerms()

### DIFF
--- a/lib/taxonomies.js
+++ b/lib/taxonomies.js
@@ -259,7 +259,7 @@ Client.prototype.syncTerms = function( callback ) {
 							// TODO: check if a term with the same name already exists
 							term.taxonomy = taxonomy;
 							if ( parent ) {
-								term.parent = parent;
+								term.parent = parent.termId;
 							}
 
 							this.publishTerm( term, function( error, termId ) {


### PR DESCRIPTION
This fixes the segfaults that folks were experiencing in https://github.com/jquery/api.jquery.com/issues/890 and also on the jQuery Mobile API site, both of which have child terms in their taxonomies.