### PR TITLE
taxonomies: Do not delete the default category

### DIFF
--- a/lib/taxonomies.js
+++ b/lib/taxonomies.js
@@ -197,6 +197,13 @@ Client.prototype.deleteTerm = function( term, callback ) {
 
 	var name = prettyTermName( term );
 
+	if ( term.taxonomy === "category" && term.termId === "1" ) {
+		// Do not try to delete the default category,
+		// as it can't be deleted.
+		callback( null );
+		return;
+	}
+
 	if ( this.verbose ) {
 		this.log( "Deleting " + name + "..." );
 	}


### PR DESCRIPTION
The default category ("Uncategorized") can't be deleted.