### PR TITLE
Validate server version as same-or-newer instead of strictly equal

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,8 +176,14 @@ Client.prototype.validateXmlrpcVersion = function( callback ) {
 			return callback( error );
 		}
 
-		if ( xmlrpcVersion !== version ) {
-			return callback( new Error( "Mismatching versions for Gilded WordPress. " +
+		// The server should have all capabilities expected by this client.
+		// The server must therefore be in the "^x.y.z" semver-range, whereby it
+		// implements the same major version, and the same (or newer) minor version.
+		var xmlrpcVersionParts = xmlrpcVersion.split( ".", 3 ).map( parseFloat );
+		var clientVersionParts = version.split( ".", 3 ).map( parseFloat );
+
+		if ( !( xmlrpcVersionParts[0] === clientVersionParts[0] && xmlrpcVersionParts[1] >= clientVersionParts[1] ) ) {
+			return callback( new Error( "Incompatible versions for Gilded WordPress. " +
 				"Version " + version + " is installed as a Node.js module, " +
 				"but the WordPress server is running version " + xmlrpcVersion + "." ) );
 		}


### PR DESCRIPTION
Allow the version to be semver-major compatible with a newer minor
version. This makes it more obvious in which order changes should
be deployed. I.e. first deploy the WordPress plugin update, and then
(optionally, gradually) update package.json in content repos.

This is partially blocking the ability to enforce use of
package-lock.json, because up until now, jQuery Infra ran `npm update`
as part of builder's webhook handlers, thus bypassing the lock file.

Once that step is removed, the true version is exposed, and thus
content changes would no longer auto-update. We could mandate that
all content repos (and their older version branches) are always using
the latest version, but I'd rather build a bit more tolerance in the
stack.

Ref https://github.com/jquery/infrastructure-puppet/issues/39.
Ref https://github.com/jquery/infrastructure-puppet/issues/38.
